### PR TITLE
node version 8.9.0 (#6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@
 dist: precise
 language: node_js
 node_js:
-  - 6
-  - 8
+  - 8.9.0
 cache:
   directories:
   - node_modules
@@ -25,11 +24,3 @@ env:
     - TEST_SUITE=simple
     - TEST_SUITE=installs
     - TEST_SUITE=kitchensink
-matrix:
-  include:
-    - node_js: 0.10
-      env: TEST_SUITE=simple
-# There's a weird Yarn/Lerna bug related to prerelease versions.
-# TODO: reenable after we ship 1.0.
-#    - node_js: 6
-#      env: USE_YARN=yes TEST_SUITE=simple

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install it once globally:
 npm install -g create-react-app
 ```
 
-**You’ll need to have Node >= 6 on your machine**. You can use [nvm](https://github.com/creationix/nvm#installation) to easily switch Node versions between different projects.
+**You’ll need to have Node >= 8.9.0 on your machine**. You can use [nvm](https://github.com/creationix/nvm#installation) to easily switch Node versions between different projects.
 
 **This tool doesn’t assume a Node backend**. The Node installation is only required for Create React App itself.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,17 +2,11 @@ image: Visual Studio 2017
 
 environment:
   matrix:
-    - nodejs_version: 8
+    - nodejs_version: 8.9.0
       test_suite: "simple"
-    - nodejs_version: 8
+    - nodejs_version: 8.9.0
       test_suite: "installs"
-    - nodejs_version: 8
-      test_suite: "kitchensink"
-    - nodejs_version: 6
-      test_suite: "simple"
-    - nodejs_version: 6
-      test_suite: "installs"
-    - nodejs_version: 6
+    - nodejs_version: 8.9.0
       test_suite: "kitchensink"
 
 cache:

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -5,7 +5,7 @@
   "repository": "stinkstudios/create-react-app",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8.9.0"
   },
   "bugs": {
     "url": "https://github.com/stinkstudios/create-react-app/issues"


### PR DESCRIPTION
We only need node 8.9.0 for now. No need to support older node